### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Kimiyuki Onaka
+Copyright (c) 2019 kimiyuki, tsutaj, beet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
これまでライセンスはとりあえず私の名前で MIT License にしていました。@beet-aizu の分だけなら少量だし暗黙の同意があると思って省略して構わなかったと思うのですが、ドキュメント生成は本質部分の初期の実装からすべて @tsutaj なので現状はあまり好ましくないです。なので著作権者の部分を修正しておきます。

@beet-aizu @tsutaj 共に問題なさそうならマージしてください