### PR TITLE
improve codes about timeout of verification

### DIFF
--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -1,6 +1,7 @@
 # Python Version: 3.x
 import argparse
 import glob
+import math
 import os
 import pathlib
 import subprocess
@@ -48,9 +49,12 @@ def subcommand_run(paths: List[pathlib.Path]) -> None:
         logger.info('$ git checkout %s', branch)
         subprocess.check_call(['git', 'checkout', branch])
 
+    # NOTE: the GITHUB_TOKEN expires in 60 minutes (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret)
+    timeout = 50 * 60 if 'GITHUB_ACTION' in os.environ else math.inf
+
     if not paths:
         paths = list(map(pathlib.Path, glob.glob('**/*.test.cpp', recursive=True)))
-    onlinejudge_verify.verify.main(paths)
+    onlinejudge_verify.verify.main(paths, timeout=timeout)
 
     # push
     if does_push:

--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -50,7 +50,8 @@ def subcommand_run(paths: List[pathlib.Path]) -> None:
         subprocess.check_call(['git', 'checkout', branch])
 
     # NOTE: the GITHUB_TOKEN expires in 60 minutes (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret)
-    timeout = 50 * 60 if 'GITHUB_ACTION' in os.environ else math.inf
+    # use 10 minutes as timeout for safety; 理由はよく分かってないぽいけど以前 20 分でやって死んだことがあるらしいので
+    timeout = 10 * 60 if 'GITHUB_ACTION' in os.environ else math.inf
 
     if not paths:
         paths = list(map(pathlib.Path, glob.glob('**/*.test.cpp', recursive=True)))


### PR DESCRIPTION
timeout 機能の修正です
@beet-aizu 問題なさそうならマージよろしく

1. コメントを足します
1. `$GITHUB_TOKEN` は 60 分間使えるらしいので timeout を 50 分ぐらいに伸ばしておきます

(@beet-aizu 何のために存在するのかがぱっと見て分からないような機能がコメントもなしに書かれていると、うっかり壊されがちです。そのような不幸を減らすために、やばそうな箇所には短くてもよいのでコメントを書いておいてください。よろしくお願いします :bow:)