### PR TITLE
use .verify-helper/cache/ to store test cases

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,0 +1,12 @@
+{
+"example.test.cpp": "2019-11-24 04:01:18 +0900",
+"examples/develop.test.cpp": "2019-12-09 19:29:58 +0900",
+"examples/gcc_only.test.cpp": "2019-11-29 11:36:33 +0900",
+"examples/include_relative.test.cpp": "2019-12-04 23:29:22 +0900",
+"examples/segment_tree.point_set_range_composite.test.cpp": "2019-12-09 18:30:56 +0900",
+"examples/segment_tree.range_minimum_query.test.cpp": "2019-12-09 18:30:56 +0900",
+"examples/segment_tree.range_sum_query.test.cpp": "2019-12-09 18:30:56 +0900",
+"examples/union_find_tree.aoj.test.cpp": "2019-12-09 18:30:56 +0900",
+"examples/union_find_tree.yosupo.test.cpp": "2019-12-09 18:30:56 +0900",
+"~": "dummy"
+}

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -51,7 +51,7 @@ def main(paths: List[pathlib.Path], *, timeout: float = math.inf) -> None:
 
             assert ('PROBLEM' in macros)
             url = shlex.split(macros['PROBLEM'])[0]
-            directory = pathlib.Path('.verify-helper') / hashlib.md5(url.encode()).hexdigest()
+            directory = pathlib.Path('.verify-helper/cache') / hashlib.md5(url.encode()).hexdigest()
 
             if not directory.exists():
                 directory.mkdir()


### PR DESCRIPTION
`.verify-helper/` に散らかしてたテストケースなどを `.verify-helper/cache/` にまとめます。

ところでこれがあると、そのディレクトリを [cache action](https://help.github.com/ja/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows) に入れることで verify が最高で 2 倍速になります。設定面倒で不安定になりがちなわりに高々 2 倍速にしかならないので、たいていの人は設定をするべきではないですが、 @beet-aizu にとっては役に立つと思います