### PR TITLE
use @functools.lru_cache() for subprocess.check_output()s

### DIFF
--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -5,7 +5,6 @@ import os
 import pathlib
 import re
 import shutil
-import subprocess
 import traceback
 # typing.OrderedDict is not recognized by mypy
 from collections import OrderedDict
@@ -43,11 +42,6 @@ def _get_marker(*, _dummy=[]) -> utils.VerificationMarker:
             timestamps_json_path = pathlib.Path('.verify-helper/timestamps.local.json')
         _dummy.append(utils.VerificationMarker(json_path=timestamps_json_path))
     return _dummy[0]
-
-
-def get_current_branch() -> str:
-    code = r'git symbolic-ref --short HEAD'
-    return subprocess.check_output(code, shell=True).decode().strip()
 
 
 class FileParser:
@@ -253,7 +247,7 @@ class MarkdownArticle(MarkdownPage):
 
         top_page_category_link = back_to_top_link + '#' + hashlib.md5(category.encode()).hexdigest()
         if categorize: file_object.write('* category: {}\n'.format(self.get_linktag(category, top_page_category_link)).encode())
-        github_link = '{{ site.github.repository_url }}' + '/blob/{}/{}'.format(get_current_branch(), str(self.file_class.file_path.relative_to(self.file_class.source_path)))
+        github_link = '{{ site.github.repository_url }}' + '/blob/{}/{}'.format('master', str(self.file_class.file_path.relative_to(self.file_class.source_path)))
         file_object.write('* {}\n    - Last commit date: {}\n'.format(self.get_linktag('View this file on GitHub', github_link), utils.get_last_commit_time_to_verify(self.file_class.file_path, compiler='g++')).encode())
         file_object.write(b'\n\n')
 
@@ -341,7 +335,7 @@ class MarkdownArticle(MarkdownPage):
         file_object.write(b'\n```\n{% endraw %}\n\n')
 
         try:
-            bundler = onlinejudge_verify.bundle.Bundler(iquote=[self.cpp_source_path])
+            bundler = onlinejudge_verify.bundle.Bundler(iquotes=[self.cpp_source_path])
             bundler.update(self.file_class.file_path)
             bundled_code = bundler.get()
         except onlinejudge_verify.bundle.BundleError:

--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -160,7 +160,7 @@ def subcommand_docs() -> None:
 
 
 def subcommand_bundle(path: pathlib.Path, *, iquote: pathlib.Path) -> None:
-    bundler = onlinejudge_verify.bundle.Bundler(iquote=[iquote])
+    bundler = onlinejudge_verify.bundle.Bundler(iquotes=[iquote])
     bundler.update(path)
     sys.stdout.buffer.write(bundler.get())
 

--- a/onlinejudge_verify/utils.py
+++ b/onlinejudge_verify/utils.py
@@ -1,4 +1,5 @@
 # Python Version: 3.x
+import functools
 import json
 import os
 import pathlib
@@ -55,13 +56,19 @@ class VerificationMarker(object):
         self.save_timestamps()
 
 
-def list_depending_files(path: pathlib.Path, *, compiler: str) -> List[pathlib.Path]:
+@functools.lru_cache(maxsize=None)
+def _list_depending_files(path: pathlib.Path, *, compiler: str) -> List[pathlib.Path]:
     code = r"""{} {} -I . -MD -MF /dev/stdout -MM {} | sed '1s/[^:].*: // ; s/\\$//' | xargs -n 1""".format(compiler, CXXFLAGS, shlex.quote(str(path)))
     data = subprocess.check_output(code, shell=True)
     return list(map(pathlib.Path, data.decode().splitlines()))
 
 
-def list_defined_macros(path: pathlib.Path, *, compiler: str) -> Dict[str, str]:
+def list_depending_files(path: pathlib.Path, *, compiler: str = CXX) -> List[pathlib.Path]:
+    return _list_depending_files(path.resolve(), compiler=compiler)
+
+
+@functools.lru_cache(maxsize=None)
+def _list_defined_macros(path: pathlib.Path, *, compiler: str) -> Dict[str, str]:
     code = r"""{} {} -I . -dM -E {}""".format(compiler, CXXFLAGS, shlex.quote(str(path)))
     data = subprocess.check_output(code, shell=True)
     define = {}
@@ -72,7 +79,27 @@ def list_defined_macros(path: pathlib.Path, *, compiler: str) -> Dict[str, str]:
     return define
 
 
-def get_last_commit_time_to_verify(path: pathlib.Path, *, compiler: str) -> str:
+def list_defined_macros(path: pathlib.Path, *, compiler: str = CXX) -> Dict[str, str]:
+    return _list_defined_macros(path.resolve(), compiler=compiler)
+
+
+@functools.lru_cache(maxsize=None)
+def _get_last_commit_time_to_verify(path: pathlib.Path, *, compiler: str) -> str:
     depending_files = list_depending_files(path, compiler=compiler)
     code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + list(map(lambda x: shlex.quote(str(x)), depending_files))
     return subprocess.check_output(code).decode().strip()
+
+
+def get_last_commit_time_to_verify(path: pathlib.Path, *, compiler: str = CXX) -> str:
+    return _get_last_commit_time_to_verify(path.resolve(), compiler=compiler)
+
+
+@functools.lru_cache(maxsize=None)
+def _get_uncommented_code(path: pathlib.Path, *, iquotes_options: str, compiler: str) -> bytes:
+    command = """{} {} -fpreprocessed -dD -E {} | tail -n +2""".format(compiler, iquotes_options, shlex.quote(str(path)))
+    return subprocess.check_output(command, shell=True)
+
+
+def get_uncommented_code(path: pathlib.Path, *, iquotes: List[pathlib.Path], compiler: str = CXX) -> bytes:
+    iquotes_options = ' '.join(map(lambda iquote: '-I {}'.format(shlex.quote(str(iquote.resolve()))), iquotes))
+    return _get_uncommented_code(path.resolve(), iquotes_options=iquotes_options, compiler=compiler)


### PR DESCRIPTION
`g++` を叩くのが遅いんですが、何度も同じコマンドを叩いてて無駄だったのでキャッシュします。
このレポジトリの 2 回目の `oj-verify all` が 4 倍速になります (13sec → 3sec)