### PR TITLE
exit with a non-zero code when test failed

### DIFF
--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -110,4 +110,4 @@ def main(paths: List[pathlib.Path], *, marker: utils.VerificationMarker, timeout
         logger.error('%d test failed', len(failed_test_paths))
         for path in failed_test_paths:
             logger.error('failed: %s', str(path))
-        sys.exit(1)
+        raise Exception('{} test failed'.format(len(failed_test_paths)))


### PR DESCRIPTION
#76 の続き。failedなものがあったらexitcodeを1にする

> だいたい動いてそう: https://kmyk.github.io/competitive-programming-library/verify/failure.test.cpp.html
> しかし CI が成功扱いになってバッジ [![GitHub Pages](https://camo.githubusercontent.com/a050504fc6dfc6aabfb160464a4c5f70cf490940/68747470733a2f2f696d672e736869656c64732e696f2f7374617469632f76313f6c6162656c3d4769744875622b5061676573266d6573736167653d2b26636f6c6f723d627269676874677265656e266c6f676f3d676974687562)](https://kmyk.github.io/competitive-programming-library/) が緑色のままなのはまずいです
> 
> @sash2104 failed なものがあったら exitcode を 1 にする (+ エラーログ出力) 処理を書いて追加のプルリクを投げてほしいです。よろしくお願いします

### 実行例
```bash
$ oj-verify all
...
ERROR:onlinejudge_verify.verify:2 test failed
ERROR:onlinejudge_verify.verify:failed: examples/failed1.test.cpp
ERROR:onlinejudge_verify.verify:failed: examples/failed2.test.cpp
...
$ echo $?
1
```