### PR TITLE
高速化

### DIFF
--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -164,6 +164,10 @@ def main(args: Optional[List[str]] = None) -> None:
     parser = get_parser()
     parsed = parser.parse_args(args)
 
+    if parsed.jobs is not None:
+        # 先に並列で読み込みしておく
+        utils.get_verification_marker(jobs=parsed.jobs)
+
     if parsed.subcommand == 'all':
         try:
             subcommand_run(paths=[], jobs=parsed.jobs)


### PR DESCRIPTION
#49

- Library Checker の関連の無駄を削除 (一部は https://github.com/kmyk/online-judge-tools/pull/643 )
- `timestamps.*.json` を読み込むときにやる処理 (ファイル間の依存性解析など) が遅いので並列化