### PR TITLE
Move md-output to .verify-helper/markdown

### DIFF
--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -495,7 +495,7 @@ class MarkdownTopPage(MarkdownPage):
 
 
 class PagesBuilder:
-    def __init__(self, *, cpp_source_pathstr: str, md_destination_pathstr: str = './md-output', config: Dict[str, Any] = {}) -> None:
+    def __init__(self, *, cpp_source_pathstr: str, md_destination_pathstr: str = '.verify-helper/markdown', config: Dict[str, Any] = {}) -> None:
         cpp_source_path = pathlib.Path(cpp_source_pathstr).resolve()
         md_destination_path = pathlib.Path(md_destination_pathstr).resolve()
 

--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -145,7 +145,7 @@ def subcommand_docs() -> None:
             onlinejudge_verify.docs.main(html=False, force=True)
 
             logger.info('upload documents...')
-            push_documents_to_gh_pages(src_dir=pathlib.Path('md-output'))
+            push_documents_to_gh_pages(src_dir=pathlib.Path('.verify-helper/markdown'))
 
     else:
         logger.info('generate documents...')


### PR DESCRIPTION
生成先が md-output だといろんな干渉が起こって邪魔なので隠します