### PR TITLE
use GITHUB_TOKEN to determine whether do push or not instead of GITHUB_TOKEN

### DIFF
--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -44,7 +44,7 @@ def subcommand_run(paths: List[pathlib.Path], *, jobs: int = 1) -> None:
     :raises Exception: if test.sh fails
     """
 
-    does_push = 'GITHUB_ACTION' in os.environ and os.environ.get('GITHUB_REF', '').startswith('refs/heads/')  # NOTE: $GITHUB_REF may be refs/pull/... or refs/tags/...
+    does_push = 'GITHUB_ACTION' in os.environ and 'GITHUB_TOKEN' in os.environ and os.environ.get('GITHUB_REF', '').startswith('refs/heads/')  # NOTE: $GITHUB_REF may be refs/pull/... or refs/tags/...
     if does_push:
         # checkout in advance to push
         branch = os.environ['GITHUB_REF'][len('refs/heads/'):]
@@ -139,7 +139,7 @@ def push_documents_to_gh_pages(*, src_dir: pathlib.Path, dst_branch: str = 'gh-p
 
 
 def subcommand_docs() -> None:
-    if 'GITHUB_ACTION' in os.environ:
+    if 'GITHUB_ACTION' in os.environ and 'GITHUB_TOKEN' in os.environ:
         if os.environ['GITHUB_REF'] == 'refs/heads/master':
             logger.info('generate documents...')
             onlinejudge_verify.docs.main(html=False, force=True)


### PR DESCRIPTION
そもそも実装が微妙にバグってるので修正します。
push するには `GITHUB_TOKEN`  (`GITHUB_TOKEN` は実質パスワードなので `hoge.yml` に設定しろと書かない限りは設定されない) を設定する必要があるんですが、`GITHUB_ACTION`  (これは常に定義される) が定義されてると `GITHUB_TOKEN` が定義されてなくても push しようとしちゃう。これを入れるとこの問題が消えます。さらに  `env -u ...` なしで 単に `GITHUB_TOKEN` を消せば `sanitize.yml` みたいなのが動くようになります。