### PR TITLE
Yukicoder token update

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,12 +13,11 @@ jobs:
       uses: actions/setup-python@v1
 
     - name: Install dependencies
-      run: pip3 install -U git+https://github.com/beet-aizu/online-judge-verify-helper.git@yukicoder_token
+      run: pip3 install -U git+https://github.com/kmyk/online-judge-verify-helper.git@master
 
     - name: Run tests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         YUKICODER_TOKEN: ${{ secrets.YUKICODER_TOKEN }}
         GH_PAT: ${{ secrets.GH_PAT }}
-      run:
-        git clone https://github.com/kmyk/online-judge-tools;cd online-judge-tools;pip3 install -e .;cd ..;oj-verify all
+      run: oj-verify all

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -19,6 +19,7 @@ logger = getLogger(__name__)
 
 
 def exec_command(command: List[str]):
+    # NOTE: secrets like YUKICODER_TOKEN are masked
     logger.info('$ %s', ' '.join(command))
 
     cwd = pathlib.Path.cwd()

--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -63,10 +63,14 @@ def verify_file(path: pathlib.Path, *, compilers: List[str], jobs: int) -> bool:
             exec_command(['sleep', '2'])
             command = ['oj', 'download', '--system', '-d', shlex.quote(str(directory / 'test')), url]
 
-            if isinstance(problem, onlinejudge.service.yukicoder.YukicoderProblem):
-                assert 'YUKICODER_TOKEN' in os.environ
+            if os.environ.get('YUKICODER_TOKEN'):
                 command += ['--yukicoder-token', os.environ['YUKICODER_TOKEN']]
-            exec_command(command)
+            try:
+                exec_command(command)
+            except:
+                if isinstance(problem, onlinejudge.service.yukicoder.YukicoderProblem) and not os.environ.get('YUKICODER_TOKEN'):
+                    logger.warning('the $YUKICODER_TOKEN environment variable is not set')
+                raise
 
         # compile the ./a.out
         language.compile(path, basedir=pathlib.Path.cwd(), tempdir=directory)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     install_requires=[
         'markdown',
         'pyyaml',
+        'online-judge-tools >= 8.0.0',
         'setuptools',
         'toml',
     ],


### PR DESCRIPTION
- デバッグ用に使われていた設定を戻す
- `YUKICODER_TOKEN` の使い方を修正
   - 手元でログインしてたら `YUKICODER_TOKEN` がなくても動く + `assert` で雑に落とすと何故落ちたのか分からないので warning で説明を書く
- secrets が出力されてるけど mask されるので安全なことを明記