### PR TITLE
Add Gemfile for generated documents

### DIFF
--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -31,6 +31,10 @@ deployed_assets = [
         'path': pathlib.Path('assets/js/copy-button.js'),
         'data': pkg_resources.resource_string(package, 'assets/js/copy-button.js'),
     },
+    {
+        'path': pathlib.Path('Gemfile'),
+        'data': pkg_resources.resource_string(package, 'Gemfile'),
+    },
 ]
 
 

--- a/onlinejudge_verify_resources/Gemfile
+++ b/onlinejudge_verify_resources/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
close #94 

手元でもドキュメントが簡単に確認できるようになります。実際に見るためのコマンドは次:

``` console
$ cd .verify-helper/markdown/
$ sudo apt install ruby-bundler
$ bundle install --path .vendor/bundle
$ bundle exec jekyll serve
# open http://localhost:4000/ on your browser
```