### PR TITLE
Improve the output in cases where some tests failed

### DIFF
--- a/onlinejudge_verify/verify.py
+++ b/onlinejudge_verify/verify.py
@@ -127,7 +127,7 @@ def main(paths: List[pathlib.Path], *, marker: onlinejudge_verify.marker.Verific
 
     # failするテストがあったらraiseする
     if len(failed_test_paths) > 0:
-        logger.error('%d test failed', len(failed_test_paths))
+        logger.error('%d tests failed', len(failed_test_paths))
         for path in failed_test_paths:
             logger.error('failed: %s', str(path))
-        raise Exception('{} test failed'.format(len(failed_test_paths)))
+        raise Exception('{} tests failed: {}'.format(len(failed_test_paths), [str(path.relative_to(pathlib.Path.cwd())) for path in failed_test_paths]))


### PR DESCRIPTION
close #150
cc @noshi91

ログの末尾が以下のようになります

``` python
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/oj-verify", line 11, in <module>
    load_entry_point('online-judge-verify-helper', 'console_scripts', 'oj-verify')()
  File "/home/ubuntu/GitHub/online-judge-verify-helper/onlinejudge_verify/main.py", line 181, in main
    subcommand_run(paths=[], jobs=parsed.jobs)
  File "/home/ubuntu/GitHub/online-judge-verify-helper/onlinejudge_verify/main.py", line 59, in subcommand_run
    onlinejudge_verify.verify.main(paths, marker=marker, timeout=timeout, jobs=jobs)
  File "/home/ubuntu/GitHub/online-judge-verify-helper/onlinejudge_verify/verify.py", line 133, in main
    raise Exception('{} tests failed: {}'.format(len(failed_test_paths), [str(path.relative_to(pathlib.Path.cwd())) for path in failed_test_paths]))
Exception: 3 tests failed: ['bar.test.cpp', 'baz.test.cpp', 'foo.test.cpp']
```