### PR TITLE
Add the suffix field for config.toml

### DIFF
--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -14,9 +14,10 @@ from typing import IO, Any, Dict, List, Tuple
 
 import markdown
 import onlinejudge_verify.languages
-import onlinejudge_verify.marker
 import pkg_resources
 import yaml
+from onlinejudge_verify.marker import get_verification_marker
+from onlinejudge_verify.utils import is_verification_file
 
 logger = getLogger(__name__)
 
@@ -149,8 +150,8 @@ class CppFile:
 
         self.required = []
         # 表示するverification statusを決める
-        is_verified = onlinejudge_verify.marker.get_verification_marker().is_verified(self.file_path.relative_to(self.source_path))
-        is_failed = onlinejudge_verify.marker.get_verification_marker().is_failed(self.file_path.relative_to(self.source_path))
+        is_verified = get_verification_marker().is_verified(self.file_path.relative_to(self.source_path))
+        is_failed = get_verification_marker().is_failed(self.file_path.relative_to(self.source_path))
         if is_verified:
             self.verification_status = VerificationStatus.VERIFIED
         elif is_failed:
@@ -255,7 +256,7 @@ class MarkdownArticle(MarkdownPage):
         top_page_category_link = back_to_top_link + '#' + hashlib.md5(category.encode()).hexdigest()
         if categorize: file_object.write('* category: {}\n'.format(self.get_linktag(category, top_page_category_link)).encode())
         github_link = '{{ site.github.repository_url }}' + '/blob/{}/{}'.format('master', str(self.file_class.file_path.relative_to(self.file_class.source_path)))
-        file_object.write('* {}\n    - Last commit date: {}\n'.format(self.get_linktag('View this file on GitHub', github_link), onlinejudge_verify.marker.get_verification_marker().get_current_timestamp(self.file_class.file_path)).encode())
+        file_object.write('* {}\n    - Last commit date: {}\n'.format(self.get_linktag('View this file on GitHub', github_link), get_verification_marker().get_current_timestamp(self.file_class.file_path)).encode())
         file_object.write(b'\n\n')
 
     def write_contents(self, file_object: IO, path_to_title: 'OrderedDict[pathlib.Path, str]', path_to_verification: Dict[pathlib.Path, VerificationStatus]) -> None:
@@ -285,16 +286,16 @@ class MarkdownArticle(MarkdownPage):
                     raise FileNotFoundError('{} seems not to exist in path_to_title'.format(depends))
                 title = path_to_title[depends]
 
-                file_type = 'verify' if '.test.' in str(depends) else 'library'
+                file_type = 'verify' if is_verification_file(depends) else 'library'
                 link = self.get_link(self.get_destination(depends, file_type)) + '.html'
                 file_object.write('* {} {}\n'.format(mark, self.get_linktag(title, link)).encode())
             file_object.write(b'\n\n')
 
-        required_file_list = [f for f in self.file_class.required if '.test.' not in str(f)]
-        verified_file_list = [f for f in self.file_class.required if '.test.' in str(f)]
+        required_file_list = [f for f in self.file_class.required if not is_verification_file(f)]
+        verified_file_list = [f for f in self.file_class.required if is_verification_file(f)]
 
         # ビルド対象ファイルが test.cpp の場合、それに依存している test.cpp ファイルは Verified ではなく Required に入れる
-        if '.test.' in str(self.file_class.file_path):
+        if is_verification_file(self.file_class.file_path):
             required_file_list.extend(verified_file_list)
             verified_file_list = []
 
@@ -313,7 +314,7 @@ class MarkdownArticle(MarkdownPage):
                     raise FileNotFoundError('{} seems not to exist in path_to_title'.format(required))
                 title = path_to_title[required]
 
-                file_type = 'verify' if '.test.' in str(required) else 'library'
+                file_type = 'verify' if is_verification_file(required) else 'library'
                 link = self.get_link(self.get_destination(required, file_type)) + '.html'
                 file_object.write('* {} {}\n'.format(mark, self.get_linktag(title, link)).encode())
             file_object.write(b'\n\n')
@@ -574,7 +575,7 @@ class PagesBuilder:
         files = {}
         for path in source_path.glob(r'**/*'):
             if onlinejudge_verify.languages.get(path):
-                if is_verify and '.test.' not in str(path):
+                if is_verify and not is_verification_file(path):
                     continue
                 if any([path.samefile(ignored_file) for ignored_file in ignored_files]):
                     continue
@@ -700,7 +701,7 @@ class PagesBuilder:
             # cpp_fileを必要としている .test.cpp のstatusのlist
             required_verification_statuses = []
             for verify in cpp_class.required:
-                if '.test.' in str(verify):
+                if is_verification_file(verify):
                     required_verification_statuses.append(result[verify])
             # verification statusを解決する
             if len(required_verification_statuses) == 0:

--- a/onlinejudge_verify/languages/__init__.py
+++ b/onlinejudge_verify/languages/__init__.py
@@ -9,15 +9,20 @@ from onlinejudge_verify.languages.other import OtherLanguage
 
 _dict: Dict[str, Language] = {}
 
-_dict['.cpp'] = CPlusPlusLanguage()
-_dict['.hpp'] = _dict['.cpp']
-_dict['.csx'] = CSharpScriptLanguage()
+_dict['.test.cpp'] = CPlusPlusLanguage()
+_dict['.test.hpp'] = _dict['.test.cpp']
+_dict['.test.csx'] = CSharpScriptLanguage()
 
 config_path = pathlib.Path('.verify-helper/config.toml')
 if config_path.exists():
     for ext, config in toml.load(str(config_path)).get('languages', {}).items():
-        _dict['.' + ext] = OtherLanguage(config=config)
+        suffix = config.get('suffix', '.test.' + ext)
+        _dict[suffix] = OtherLanguage(config=config)
 
 
 def get(path: pathlib.Path) -> Optional[Language]:
-    return _dict.get(path.suffix)
+    for suffix, language in _dict.items():
+        if str(path.name).endswith(suffix):
+            return language
+    else:
+        return None

--- a/onlinejudge_verify/languages/__init__.py
+++ b/onlinejudge_verify/languages/__init__.py
@@ -1,4 +1,5 @@
 import pathlib
+from logging import getLogger
 from typing import *
 
 import toml
@@ -6,6 +7,8 @@ from onlinejudge_verify.languages.base import Language
 from onlinejudge_verify.languages.cplusplus import CPlusPlusLanguage
 from onlinejudge_verify.languages.csharpscript import CSharpScriptLanguage
 from onlinejudge_verify.languages.other import OtherLanguage
+
+logger = getLogger(__name__)
 
 _dict: Dict[str, Language] = {}
 
@@ -16,6 +19,7 @@ _dict['.test.csx'] = CSharpScriptLanguage()
 config_path = pathlib.Path('.verify-helper/config.toml')
 if config_path.exists():
     for ext, config in toml.load(str(config_path)).get('languages', {}).items():
+        logger.warn("%s: languages.%s: Adding new languages using `config.toml` is supported but not recommended. Please consider making pull requests for your languages, see https://github.com/kmyk/online-judge-verify-helper/issues/116", str(config_path), ext)
         suffix = config.get('suffix', '.test.' + ext)
         _dict[suffix] = OtherLanguage(config=config)
 

--- a/onlinejudge_verify/main.py
+++ b/onlinejudge_verify/main.py
@@ -11,8 +11,8 @@ from logging import DEBUG, basicConfig, getLogger
 from typing import *
 
 import onlinejudge_verify.docs
-import onlinejudge_verify.languages
 import onlinejudge_verify.marker
+import onlinejudge_verify.utils
 import onlinejudge_verify.verify
 
 logger = getLogger(__name__)
@@ -56,10 +56,7 @@ def subcommand_run(paths: List[pathlib.Path], *, timeout: float = 600, tle: floa
         timeout = math.inf
 
     if not paths:
-        for path in pathlib.Path.cwd().glob('**/*.test.*'):
-            if onlinejudge_verify.languages.get(path):
-                paths.append(path)
-        paths = sorted(paths)
+        paths = sorted(list(onlinejudge_verify.utils.iterate_verification_files()))
     try:
         with onlinejudge_verify.marker.get_verification_marker() as marker:
             return onlinejudge_verify.verify.main(paths, marker=marker, timeout=timeout, tle=tle, jobs=jobs)

--- a/onlinejudge_verify/marker.py
+++ b/onlinejudge_verify/marker.py
@@ -3,13 +3,13 @@ import concurrent.futures
 import datetime
 import functools
 import json
-import os
 import pathlib
 import shlex
 import subprocess
 from typing import *
 
 import onlinejudge_verify.languages
+import onlinejudge_verify.utils
 
 
 class VerificationMarker(object):
@@ -113,11 +113,11 @@ def get_verification_marker(*, jobs: Optional[int] = None) -> VerificationMarker
     global _verification_marker
     if _verification_marker is None:
         # use different files in local and in remote to avoid conflicts
-        if 'GITHUB_ACTION' in os.environ:
-            timestamps_json_path = pathlib.Path('.verify-helper/timestamps.remote.json')
-        else:
+        if onlinejudge_verify.utils.is_local_execution():
             timestamps_json_path = pathlib.Path('.verify-helper/timestamps.local.json')
-        use_git_timestamp = 'GITHUB_ACTION' in os.environ
+        else:
+            timestamps_json_path = pathlib.Path('.verify-helper/timestamps.remote.json')
+        use_git_timestamp = onlinejudge_verify.utils.is_local_execution()
         _verification_marker = VerificationMarker(json_path=timestamps_json_path, use_git_timestamp=use_git_timestamp, jobs=jobs)
     return _verification_marker
 

--- a/onlinejudge_verify/utils.py
+++ b/onlinejudge_verify/utils.py
@@ -1,6 +1,20 @@
 # Python Version: 3.x
 import os
+import pathlib
+from typing import *
+
+import onlinejudge_verify.languages
 
 
 def is_local_execution() -> bool:
     return 'GITHUB_ACTION' not in os.environ
+
+
+def is_verification_file(path: pathlib.Path) -> bool:
+    return onlinejudge_verify.languages.get(path) is not None
+
+
+def iterate_verification_files() -> Iterator[pathlib.Path]:
+    for path in pathlib.Path.cwd().glob('**/*'):
+        if is_verification_file(path):
+            yield path

--- a/onlinejudge_verify/utils.py
+++ b/onlinejudge_verify/utils.py
@@ -1,0 +1,6 @@
+# Python Version: 3.x
+import os
+
+
+def is_local_execution() -> bool:
+    return 'GITHUB_ACTION' not in os.environ


### PR DESCRIPTION
#119 の問題を解決するために `suffix` を陽に指定できるようにした。
ただし undocumented としておきます。できれば本体にプルリクを出してほしくて、`config.toml` の方を頑張って整備や後方互換性維持する気はないため

たとえば以下のように書けば動くはず

``` toml
[language.java]
suffix = "_test.java"
compile = "..."
...
```

cc @Maruoka842