### PR TITLE
Add the "verification_file_suffix" field for config.toml

### DIFF
--- a/onlinejudge_verify/languages/__init__.py
+++ b/onlinejudge_verify/languages/__init__.py
@@ -12,21 +12,16 @@ logger = getLogger(__name__)
 
 _dict: Dict[str, Language] = {}
 
-_dict['.test.cpp'] = CPlusPlusLanguage()
-_dict['.test.hpp'] = _dict['.test.cpp']
-_dict['.test.csx'] = CSharpScriptLanguage()
+_dict['.cpp'] = CPlusPlusLanguage()
+_dict['.hpp'] = _dict['.cpp']
+_dict['.csx'] = CSharpScriptLanguage()
 
 config_path = pathlib.Path('.verify-helper/config.toml')
 if config_path.exists():
     for ext, config in toml.load(str(config_path)).get('languages', {}).items():
         logger.warn("%s: languages.%s: Adding new languages using `config.toml` is supported but not recommended. Please consider making pull requests for your languages, see https://github.com/kmyk/online-judge-verify-helper/issues/116", str(config_path), ext)
-        suffix = config.get('suffix', '.test.' + ext)
-        _dict[suffix] = OtherLanguage(config=config)
+        _dict['.' + ext] = OtherLanguage(config=config)
 
 
 def get(path: pathlib.Path) -> Optional[Language]:
-    for suffix, language in _dict.items():
-        if str(path.name).endswith(suffix):
-            return language
-    else:
-        return None
+    return _dict.get(path.suffix)

--- a/onlinejudge_verify/languages/base.py
+++ b/onlinejudge_verify/languages/base.py
@@ -24,3 +24,6 @@ class Language(object):
     @abc.abstractmethod
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bytes:
         raise NotImplementedError
+
+    def is_verification_file(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bool:
+        return '.test.' in path.name

--- a/onlinejudge_verify/languages/other.py
+++ b/onlinejudge_verify/languages/other.py
@@ -46,3 +46,9 @@ class OtherLanguage(Language):
         command = self.config['bundle'].format(path=str(path), basedir=str(basedir))
         logger.info('$ %s', command)
         return subprocess.check_output(shlex.split(command))
+
+    def is_verification_file(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bool:
+        suffix = self.config.get('verification_file_suffix')
+        if suffix is not None:
+            return path.name.endswith(suffix)
+        return super().is_verification_file(path, basedir=basedir)

--- a/onlinejudge_verify/utils.py
+++ b/onlinejudge_verify/utils.py
@@ -11,7 +11,8 @@ def is_local_execution() -> bool:
 
 
 def is_verification_file(path: pathlib.Path) -> bool:
-    return onlinejudge_verify.languages.get(path) is not None
+    language = onlinejudge_verify.languages.get(path)
+    return language is not None and language.is_verification_file(path, basedir=pathlib.Path.cwd())
 
 
 def iterate_verification_files() -> Iterator[pathlib.Path]:


### PR DESCRIPTION
ref #119 #183
修正です。代わりに `verification_file_suffix ` を使ってください
cc @Maruoka842

``` toml
[language.java]
verification_file_suffix = "_test.java"
compile = "..."
...
```