### PR TITLE
Use question marks for partially failed libraries

### DIFF
--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -81,6 +81,7 @@ class FileParser:
 
 class VerificationStatus(Enum):
     VERIFIED = ':heavy_check_mark:'
+    QUESTION = ':question:'
     FAILED = ':x:'
     DEFAULT = ':warning:'
 
@@ -710,11 +711,11 @@ class PagesBuilder:
                 # 一つでもfailedならfailed、とすると自身のコードに問題ない場合も誤ってfailedとなる
                 # 可能性が高まるので避けた
                 result[cpp_file] = VerificationStatus.FAILED
-            elif all(status != VerificationStatus.DEFAULT for status in required_verification_statuses):
+            elif all(status == VerificationStatus.VERIFIED for status in required_verification_statuses):
                 # 上記以外でcpp_fileを必要としている .test.cpp が全てverifiedかfailedならverifiedとする
                 result[cpp_file] = VerificationStatus.VERIFIED
             else:
-                result[cpp_file] = VerificationStatus.DEFAULT
+                result[cpp_file] = VerificationStatus.QUESTION
             self.library_files[cpp_file].verification_status = result[cpp_file]
         return result
 

--- a/onlinejudge_verify/docs.py
+++ b/onlinejudge_verify/docs.py
@@ -708,13 +708,12 @@ class PagesBuilder:
                 result[cpp_file] = VerificationStatus.DEFAULT
             elif all(status == VerificationStatus.FAILED for status in required_verification_statuses):
                 # cpp_fileを必要としている全てのtestでfailedならfailedとする
-                # 一つでもfailedならfailed、とすると自身のコードに問題ない場合も誤ってfailedとなる
-                # 可能性が高まるので避けた
                 result[cpp_file] = VerificationStatus.FAILED
             elif all(status == VerificationStatus.VERIFIED for status in required_verification_statuses):
                 # 上記以外でcpp_fileを必要としている .test.cpp が全てverifiedかfailedならverifiedとする
                 result[cpp_file] = VerificationStatus.VERIFIED
             else:
+                # 一つでもfailedならfailed、とすると自身のコードに問題ない場合も誤ってfailedとなる可能性が高まるので避けた
                 result[cpp_file] = VerificationStatus.QUESTION
             self.library_files[cpp_file].verification_status = result[cpp_file]
         return result


### PR DESCRIPTION
> 一つでもfailedならfailed、とすると自身のコードに問題ない場合も誤ってfailedとなる可能性が高まるので避けた

という判断による仕様だったようですが、誤って verified になる可能性がある方が圧倒的にやばいので修正します

---

<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">これ挙動あってるんか？ <a href="https://t.co/1JbtARTxii">pic.twitter.com/1JbtARTxii</a></p>&mdash; beet (@beet_aizu) <a href="https://twitter.com/beet_aizu/status/1235878122932695042?ref_src=twsrc%5Etfw">March 6, 2020</a></blockquote>
<blockquote class="twitter-tweet"><p lang="ja" dir="ltr">テストが落ちてるのに依存先が✅ついてり</p>&mdash; beet (@beet_aizu) <a href="https://twitter.com/beet_aizu/status/1235878197041885184?ref_src=twsrc%5Etfw">March 6, 2020</a></blockquote>