### PR TITLE
Add settings to set compilers

### DIFF
--- a/.verify-helper/docs/static/document.ja.md
+++ b/.verify-helper/docs/static/document.ja.md
@@ -4,13 +4,44 @@
 
 ## 対応している言語
 
-| 言語 | コンパイラ | 属性指定方法 | 対応機能 (verify / bundle / doc) | 例 |
+一覧表:
+
+| 言語 | コンパイラ | 対応機能 (verify / bundle / doc) | 例 |
 |---|---|---|---|---|
-| C++ | GCC / Clang | `#define [KEY] [VALUE]` | :heavy_check_mark: / :heavy_check_mark: / :heavy_check_mark: | [examples/segment_tree.range_sum_query.test.cpp](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/segment_tree.range_sum_query.test.cpp) |
-| C# script | .NET Core | `#pragma [KEY] [VALUE]` | :heavy_check_mark: / :x: / :warning: | [examples/csharpscript/segment_tree.range_sum_query.test.csx](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/csharpscript/segment_tree.range_sum_query.test.csx) |
+| C++ | GCC / Clang | :heavy_check_mark: / :heavy_check_mark: / :heavy_check_mark: | [examples/segment_tree.range_sum_query.test.cpp](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/segment_tree.range_sum_query.test.cpp) |
+| C# script | .NET Core | :heavy_check_mark: / :x: / :warning: | [examples/csharpscript/segment_tree.range_sum_query.test.csx](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/csharpscript/segment_tree.range_sum_query.test.csx) |
 
-上記以外の言語でも実行可能です (例: [examples/awk/circle.test.awk](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/awk/circle.test.awk))。 `.verify-helper/config.toml` というファイルを作って、コンパイルや実行のためのコマンドを書いてください。 (例: [.verify-helper/config.toml](https://github.com/kmyk/online-judge-verify-helper/blob/master/.verify-helper/config.toml))
+### C++ の設定
 
+`.verify-helper/config.toml` というファイルを作って以下のように設定を設定を書くと、コンパイラやそのオプションを指定できます。
+設定がない場合は、自動でコンパイラ (`g++` と `clang++`) を検出し、おすすめのオプションを用いて実行されます。
+
+``` toml
+[[languages.cpp.environments]]
+CXX = "g++"
+
+[[languages.cpp.environments]]
+CXX = "clang++"
+CXXFLAGS = ["-std=c++17", "-Wall", "-g", "-fsanitize=undefined", "-D_GLIBCXX_DEBUG"]
+```
+
+### C# script の設定
+
+設定項目はありません。
+
+### その他の言語の設定
+
+上記以外の言語でも実行可能です (例: [examples/awk/circle.test.awk](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/awk/circle.test.awk))。
+`.verify-helper/config.toml` というファイルを作って、以下のようにコンパイルや実行のためのコマンドを書いてください (例: [.verify-helper/config.toml](https://github.com/kmyk/online-judge-verify-helper/blob/master/.verify-helper/config.toml))。
+
+``` toml
+[languages.awk]
+compile = "bash -c 'echo hello > {tempdir}/hello'"
+execute = "env AWKPATH={basedir} awk -f {path}"
+bundle = "false"
+list_attributes = "sed 's/^# verify-helper: // ; t ; d' {path}"
+list_dependencies = "sed 's/^@include \"\\(.*\\)\"$/\\1/ ; t ; d' {path}"
+```
 
 ## verify 自動実行
 
@@ -25,7 +56,7 @@
 
 これらの他サービスはテストケースを利用できる形で公開してくれていないため利用できません。
 
-### 利用可能なマクロ定義
+### 利用可能な属性
 
 |変数名|説明|備考|
 |---|---|---|

--- a/.verify-helper/docs/static/document.md
+++ b/.verify-helper/docs/static/document.md
@@ -4,12 +4,43 @@
 
 ## Supported languages
 
+Summary:
+
 | Language | Compilers | How to specify attributes | Features (verify / bundle / doc) | Examples |
 |---|---|---|---|---|
 | C++ | GCC / Clang | `#define [KEY] [VALUE]` | :heavy_check_mark: / :heavy_check_mark: / :heavy_check_mark: | [examples/segment_tree.range_sum_query.test.cpp](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/segment_tree.range_sum_query.test.cpp) |
 | C# script | .NET Core | `#pragma [KEY] [VALUE]` | :heavy_check_mark: / :x: / :warning: | [examples/csharpscript/segment_tree.range_sum_query.test.csx](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/csharpscript/segment_tree.range_sum_query.test.csx) |
 
+### Settings for C++
+
+You can specify compilers and options with writing `.verify-helper/config.toml` as below.
+If there is no settings, online-judge-verify-helper automatically detects compilers (`g++` and `clang++` if exists) and use recommended options.
+
+``` toml
+[[languages.cpp.environments]]
+CXX = "g++"
+
+[[languages.cpp.environments]]
+CXX = "clang++"
+CXXFLAGS = ["-std=c++17", "-Wall", "-g", "-fsanitize=undefined", "-D_GLIBCXX_DEBUG"]
+```
+
+### Settings for C#
+
+No config
+
+### Settings for other languages
+
 You can use languages other than above (e.g. AWK [examples/awk/circle.test.awk](https://github.com/kmyk/online-judge-verify-helper/blob/master/examples/awk/circle.test.awk)). Please write commands to compile and execute in the config file `.verify-helper/config.toml` (e.g. [.verify-helper/config.toml](https://github.com/kmyk/online-judge-verify-helper/blob/master/.verify-helper/config.toml)).
+
+``` toml
+[languages.awk]
+compile = "bash -c 'echo hello > {tempdir}/hello'"
+execute = "env AWKPATH={basedir} awk -f {path}"
+bundle = "false"
+list_attributes = "sed 's/^# verify-helper: // ; t ; d' {path}"
+list_dependencies = "sed 's/^@include \"\\(.*\\)\"$/\\1/ ; t ; d' {path}"
+```
 
 ## Automating the verification
 

--- a/onlinejudge_verify/config.py
+++ b/onlinejudge_verify/config.py
@@ -1,0 +1,15 @@
+# Python Version: 3.x
+import functools
+import pathlib
+from typing import *
+
+import toml
+
+config_path = pathlib.Path('.verify-helper/config.toml')
+
+
+@functools.lru_cache(maxsize=None)
+def get_config() -> Dict[str, Any]:
+    if not config_path.exists():
+        return {}
+    return dict(toml.load(str(config_path)))

--- a/onlinejudge_verify/languages/__init__.py
+++ b/onlinejudge_verify/languages/__init__.py
@@ -3,9 +3,9 @@ from logging import getLogger
 from typing import *
 
 import toml
-from onlinejudge_verify.languages.base import Language
 from onlinejudge_verify.languages.cplusplus import CPlusPlusLanguage
 from onlinejudge_verify.languages.csharpscript import CSharpScriptLanguage
+from onlinejudge_verify.languages.models import Language, LanguageEnvironment
 from onlinejudge_verify.languages.other import OtherLanguage
 
 logger = getLogger(__name__)
@@ -20,6 +20,8 @@ config_path = pathlib.Path('.verify-helper/config.toml')
 if config_path.exists():
     for ext, config in toml.load(str(config_path)).get('languages', {}).items():
         logger.warn("%s: languages.%s: Adding new languages using `config.toml` is supported but not recommended. Please consider making pull requests for your languages, see https://github.com/kmyk/online-judge-verify-helper/issues/116", str(config_path), ext)
+        if '.' + ext in _dict:
+            raise RuntimeError("You cannot overwrite existing language: .{}".format(ext))
         _dict['.' + ext] = OtherLanguage(config=config)
 
 

--- a/onlinejudge_verify/languages/__init__.py
+++ b/onlinejudge_verify/languages/__init__.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import *
 
 import toml
+from onlinejudge_verify.config import config_path, get_config
 from onlinejudge_verify.languages.cplusplus import CPlusPlusLanguage
 from onlinejudge_verify.languages.csharpscript import CSharpScriptLanguage
 from onlinejudge_verify.languages.models import Language, LanguageEnvironment
@@ -16,12 +17,13 @@ _dict['.cpp'] = CPlusPlusLanguage()
 _dict['.hpp'] = _dict['.cpp']
 _dict['.csx'] = CSharpScriptLanguage()
 
-config_path = pathlib.Path('.verify-helper/config.toml')
-if config_path.exists():
-    for ext, config in toml.load(str(config_path)).get('languages', {}).items():
-        logger.warn("%s: languages.%s: Adding new languages using `config.toml` is supported but not recommended. Please consider making pull requests for your languages, see https://github.com/kmyk/online-judge-verify-helper/issues/116", str(config_path), ext)
-        if '.' + ext in _dict:
-            raise RuntimeError("You cannot overwrite existing language: .{}".format(ext))
+for ext, config in get_config().get('languages', {}).items():
+    logger.warn("%s: languages.%s: Adding new languages using `config.toml` is supported but not recommended. Please consider making pull requests for your languages, see https://github.com/kmyk/online-judge-verify-helper/issues/116", str(config_path), ext)
+    if '.' + ext in _dict:
+        for key in ('compile', 'execute', 'bundle', 'list_attributes', 'list_dependencies'):
+            if key in config:
+                raise RuntimeError("You cannot overwrite existing language: .{}".format(ext))
+    else:
         _dict['.' + ext] = OtherLanguage(config=config)
 
 

--- a/onlinejudge_verify/languages/cplusplus.py
+++ b/onlinejudge_verify/languages/cplusplus.py
@@ -1,5 +1,6 @@
 # Python Version: 3.x
 import functools
+import os
 import pathlib
 import platform
 import shlex
@@ -8,6 +9,7 @@ import subprocess
 from logging import getLogger
 from typing import *
 
+from onlinejudge_verify.config import get_config
 from onlinejudge_verify.languages.cplusplus_bundle import Bundler
 from onlinejudge_verify.languages.models import Language, LanguageEnvironment
 from onlinejudge_verify.languages.special_comments import list_special_comments
@@ -19,14 +21,9 @@ class CPlusPlusLanguageEnvironment(LanguageEnvironment):
     CXX: pathlib.Path
     CXXFLAGS: List[str]
 
-    def __init__(self, *, CXX: pathlib.Path, CXXFLAGS: Optional[List[str]] = None):
+    def __init__(self, *, CXX: pathlib.Path, CXXFLAGS: List[str]):
         self.CXX = CXX
-        if CXXFLAGS is not None:
-            self.CXXFLAGS = CXXFLAGS
-        else:
-            self.CXXFLAGS = ['--std=c++17', '-O2', '-Wall', '-g']
-            if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
-                self.CXXFLAGS.append('-fsplit-stack')
+        self.CXXFLAGS = CXXFLAGS
 
     def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
         command = [str(self.CXX), *self.CXXFLAGS, '-I', str(basedir), '-o', str(tempdir / 'a.out'), str(path)]
@@ -35,6 +32,12 @@ class CPlusPlusLanguageEnvironment(LanguageEnvironment):
 
     def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
         return [str(tempdir / 'a.out')]
+
+    def _is_clang(self) -> bool:
+        return 'clang++' in self.CXX.name
+
+    def _is_gcc(self) -> bool:
+        return not self._is_clang() and 'g++' in self.CXX.name
 
 
 @functools.lru_cache(maxsize=None)
@@ -60,41 +63,105 @@ def _cplusplus_list_defined_macros(path: pathlib.Path, *, CXX: pathlib.Path, joi
     return define
 
 
-@functools.lru_cache(maxsize=None)
-def _list_default_environments() -> List[CPlusPlusLanguageEnvironment]:
-    envs = []
-    for name in ('g++', 'clang++'):
-        path = shutil.which(name)
-        if path is not None:
-            envs.append(CPlusPlusLanguageEnvironment(CXX=pathlib.Path(path)))
-    return envs
+_NOT_SPECIAL_COMMENTS = '*NOT_SPECIAL_COMMENTS*'
+_PROBLEM = 'PROBLEM'
+_IGNORE = 'IGNORE'
+_IGNORE_IF_CLANG = 'IGNORE_IF_CLANG'
+_IGNORE_IF_GCC = 'IGNORE_IF_GCC'
+_ERROR = 'ERROR'
 
 
-def _get_default_CXX() -> pathlib.Path:
-    return _list_default_environments()[0].CXX
-
-
-def _get_default_CXXFLAGS() -> List[str]:
-    return _list_default_environments()[0].CXXFLAGS
-
-
-# 以前は #ifdef __clang__ #define IGNORE #endif をしていた
-def _workaround_ignore_if_clang(path: pathlib.Path, *, clang: pathlib.Path, basedir: pathlib.Path) -> bool:
-    with open(path) as fh:
-        if 'IGNORE' not in fh.read():
-            return False
-    joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
-    return 'IGNORE' in _cplusplus_list_defined_macros(path.resolve(), CXX=clang, joined_CXXFLAGS=joined_CXXFLAGS)
-
-
+# config.toml example:
+#     [[languages.cpp.environments]]
+#     CXX = "g++"
+#     CXXFALGS = ["-std=c++17", "-Wall"]
 class CPlusPlusLanguage(Language):
+    config: Dict[str, Any]
+
+    def __init__(self, *, config: Optional[Dict[str, Any]] = None):
+        if config is None:
+            self.config = get_config().get('languages', {}).get('cpp', {})
+        else:
+            self.config = config
+
+    def _list_environments(self) -> List[CPlusPlusLanguageEnvironment]:
+        default_CXXFLAGS = ['--std=c++17', '-O2', '-Wall', '-g']
+        if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
+            default_CXXFLAGS.append('-fsplit-stack')
+
+        if 'CXXFLAGS' in os.environ and 'environments' not in self.config:
+            logger.warning('Usage of $CXXFLAGS envvar to specify options is deprecated and will be removed soon')
+            print('::warning::Usage of $CXXFLAGS envvar to specify options is deprecated and will be removed soon')
+            default_CXXFLAGS = shlex.split(os.environ['CXXFLAGS'])
+
+        envs = []
+        if 'environments' in self.config:
+            # configured: use specified CXX & CXXFLAGS
+            for env in self.config['environments']:
+                CXX: str = env.get('CXX')
+                if CXX is None:
+                    raise RuntimeError('CXX is not specified')
+                CXXFLAGS: List[str] = env.get('CXXFLAGS', default_CXXFLAGS)
+                if not isinstance(CXXFLAGS, list):
+                    raise RuntimeError('CXXFLAGS must ba a list')
+                envs.append(CPlusPlusLanguageEnvironment(CXX=pathlib.Path(CXX), CXXFLAGS=CXXFLAGS))
+
+        elif 'CXX' in os.environ:
+            # old-style: 以前は $CXX を使ってたけど設定ファイルに移行したい
+            logger.warning('Usage of $CXX envvar to restrict compilers is deprecated and will be removed soon')
+            print('::warning::Usage of $CXX envvar to restrict compilers is deprecated and will be removed soon')
+            envs.append(CPlusPlusLanguageEnvironment(CXX=pathlib.Path(os.environ['CXX']), CXXFLAGS=default_CXXFLAGS))
+
+        else:
+            # default: use found compilers
+            for name in ('g++', 'clang++'):
+                path = shutil.which(name)
+                if path is not None:
+                    envs.append(CPlusPlusLanguageEnvironment(CXX=pathlib.Path(path), CXXFLAGS=default_CXXFLAGS))
+
+        if not envs:
+            raise RuntimeError('No C++ compilers found')
+        return envs
+
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
-        joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
-        return list_special_comments(path.resolve()) or _cplusplus_list_defined_macros(path.resolve(), CXX=_get_default_CXX(), joined_CXXFLAGS=joined_CXXFLAGS)
+        special_comments = list_special_comments(path.resolve())
+        if special_comments:
+            return special_comments
+
+        else:
+            # use old-style if special comments not found
+            # #define PROBLEM "https://..." の形式は複数 environments との相性がよくない。あと遅い
+            attributes: Dict[str, str] = {
+                _NOT_SPECIAL_COMMENTS: '',
+            }
+            all_ignored = True
+            for env in self._list_environments():
+                joined_CXXFLAGS = ' '.join(map(shlex.quote, [*env.CXXFLAGS, '-I', str(basedir)]))
+                macros = _cplusplus_list_defined_macros(path.resolve(), CXX=env.CXX, joined_CXXFLAGS=joined_CXXFLAGS)
+
+                # convert macros to attributes
+                if _IGNORE not in macros:
+                    for key in [_PROBLEM, _ERROR]:
+                        if all_ignored:
+                            # the first non-ignored environment
+                            if key in macros:
+                                attributes[key] = macros[key]
+                        else:
+                            assert attributes.get(key) == macros.get(key)
+                    all_ignored = False
+                else:
+                    if env._is_gcc():
+                        attributes[_IGNORE_IF_GCC] = ''
+                    if env._is_clang():
+                        attributes[_IGNORE_IF_CLANG] = ''
+            if all_ignored:
+                attributes[_IGNORE] = ''
+            return attributes
 
     def list_dependencies(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[pathlib.Path]:
-        joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
-        return _cplusplus_list_depending_files(path.resolve(), CXX=_get_default_CXX(), joined_CXXFLAGS=joined_CXXFLAGS)
+        env = self._list_environments()[0]
+        joined_CXXFLAGS = ' '.join(map(shlex.quote, [*env.CXXFLAGS, '-I', str(basedir)]))
+        return _cplusplus_list_depending_files(path.resolve(), CXX=env.CXX, joined_CXXFLAGS=joined_CXXFLAGS)
 
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bytes:
         bundler = Bundler(iquotes=[basedir])
@@ -102,16 +169,12 @@ class CPlusPlusLanguage(Language):
         return bundler.get()
 
     def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[CPlusPlusLanguageEnvironment]:
+        attributes = self.list_attributes(path, basedir=basedir)
         envs = []
-        for env in _list_default_environments():
-            # TODO: 仕様検討 このあたりどうにかする
-            # if 'clang++' in env.CXX.name and 'IGNORE_IF_CLANG' in self.list_attributes(path, basedir=basedir):
-            #     continue
-            # if 'g++' in env.CXX.name and 'IGNORE_IF_GCC' in self.list_attributes(path, basedir=basedir):
-            #     continue
-            if 'clang++' in env.CXX.name and _workaround_ignore_if_clang(path, clang=env.CXX, basedir=basedir):
-                # logger.warning('failed to make the stack size unlimited')
-                # print(f'::warning ::use IGNORE_IF_CLANG')
+        for env in self._list_environments():
+            if env._is_gcc() and _IGNORE_IF_GCC in attributes:
+                continue
+            if env._is_clang() and _IGNORE_IF_CLANG in attributes:
                 continue
             envs.append(env)
         return envs

--- a/onlinejudge_verify/languages/cplusplus.py
+++ b/onlinejudge_verify/languages/cplusplus.py
@@ -1,29 +1,54 @@
 # Python Version: 3.x
 import functools
-import os
 import pathlib
 import platform
 import shlex
+import shutil
 import subprocess
 from logging import getLogger
 from typing import *
 
-from onlinejudge_verify.languages.base import Language
 from onlinejudge_verify.languages.cplusplus_bundle import Bundler
+from onlinejudge_verify.languages.models import Language, LanguageEnvironment
+from onlinejudge_verify.languages.special_comments import list_special_comments
 
 logger = getLogger(__name__)
 
 
-@functools.lru_cache(maxsize=None)
-def _cplusplus_list_depending_files(path: pathlib.Path, *, compiler: str) -> List[pathlib.Path]:
-    code = r"""{} -MD -MF /dev/stdout -MM {} | sed '1s/[^:].*: // ; s/\\$//' | xargs -n 1""".format(compiler, shlex.quote(str(path)))
-    data = subprocess.check_output(code, shell=True)
-    return list(map(pathlib.Path, data.decode().splitlines()))
+class CPlusPlusLanguageEnvironment(LanguageEnvironment):
+    CXX: pathlib.Path
+    CXXFLAGS: List[str]
+
+    def __init__(self, *, CXX: pathlib.Path, CXXFLAGS: Optional[List[str]] = None):
+        self.CXX = CXX
+        if CXXFLAGS is not None:
+            self.CXXFLAGS = CXXFLAGS
+        else:
+            self.CXXFLAGS = ['--std=c++17', '-O2', '-Wall', '-g']
+            if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
+                self.CXXFLAGS.append('-fsplit-stack')
+
+    def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
+        command = [str(self.CXX), *self.CXXFLAGS, '-I', str(basedir), '-o', str(tempdir / 'a.out'), str(path)]
+        logger.info('$ %s', ' '.join(command))
+        subprocess.check_call(command)
+
+    def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
+        return [str(tempdir / 'a.out')]
 
 
 @functools.lru_cache(maxsize=None)
-def _cplusplus_list_defined_macros(path: pathlib.Path, *, compiler: str) -> Dict[str, str]:
-    command = [*shlex.split(compiler), '-dM', '-E', str(path)]
+def _cplusplus_list_depending_files(path: pathlib.Path, *, CXX: pathlib.Path, joined_CXXFLAGS: str) -> List[pathlib.Path]:
+    # Using /dev/stdout is acceptable because Library Chcker doesn't work on Windows.
+    command = [str(CXX), *shlex.split(joined_CXXFLAGS), '-MD', '-MF', '/dev/stdout', '-MM', str(path)]
+    data = subprocess.check_output(command)
+    makefile_rule = shlex.split(data.decode().replace('\\\n', ''))
+    return [pathlib.Path(path).resolve() for path in makefile_rule[1:]]
+
+
+@functools.lru_cache(maxsize=None)
+def _cplusplus_list_defined_macros(path: pathlib.Path, *, CXX: pathlib.Path, joined_CXXFLAGS: str) -> Dict[str, str]:
+    command = [str(CXX), *shlex.split(joined_CXXFLAGS), '-dM', '-E', str(path)]
     data = subprocess.check_output(command)
     define = {}
     for line in data.decode().splitlines():
@@ -35,35 +60,58 @@ def _cplusplus_list_defined_macros(path: pathlib.Path, *, compiler: str) -> Dict
     return define
 
 
+@functools.lru_cache(maxsize=None)
+def _list_default_environments() -> List[CPlusPlusLanguageEnvironment]:
+    envs = []
+    for name in ('g++', 'clang++'):
+        path = shutil.which(name)
+        if path is not None:
+            envs.append(CPlusPlusLanguageEnvironment(CXX=pathlib.Path(path)))
+    return envs
+
+
+def _get_default_CXX() -> pathlib.Path:
+    return _list_default_environments()[0].CXX
+
+
+def _get_default_CXXFLAGS() -> List[str]:
+    return _list_default_environments()[0].CXXFLAGS
+
+
+# 以前は #ifdef __clang__ #define IGNORE #endif をしていた
+def _workaround_ignore_if_clang(path: pathlib.Path, *, clang: pathlib.Path, basedir: pathlib.Path) -> bool:
+    with open(path) as fh:
+        if 'IGNORE' not in fh.read():
+            return False
+    joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
+    return 'IGNORE' in _cplusplus_list_defined_macros(path.resolve(), CXX=clang, joined_CXXFLAGS=joined_CXXFLAGS)
+
+
 class CPlusPlusLanguage(Language):
-    CXX: str
-    CXXFLAGS: str
-
-    def __init__(self, *, CXX: str = os.environ.get('CXX', 'g++'), CXXFLAGS: Optional[str] = os.environ.get('CXXFLAGS')):
-        self.CXX = CXX
-        if CXXFLAGS is None:
-            CXXFLAGS = '--std=c++17 -O2 -Wall -g'
-            if platform.uname().system == 'Linux' and 'Microsoft' in platform.uname().release:
-                CXXFLAGS += ' -fsplit-stack'
-        self.CXXFLAGS = CXXFLAGS
-
-    def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
-        command = [self.CXX, *shlex.split(self.CXXFLAGS), '-I', str(basedir), '-o', str(tempdir / 'a.out'), str(path)]
-        logger.info('$ %s', ' '.join(command))
-        subprocess.check_call(command)
-
-    def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
-        return [str(tempdir / 'a.out')]
-
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
-        compiler = ' '.join([self.CXX, self.CXXFLAGS, '-I', str(basedir)])
-        return _cplusplus_list_defined_macros(path.resolve(), compiler=compiler)
+        joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
+        return list_special_comments(path.resolve()) or _cplusplus_list_defined_macros(path.resolve(), CXX=_get_default_CXX(), joined_CXXFLAGS=joined_CXXFLAGS)
 
     def list_dependencies(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[pathlib.Path]:
-        compiler = ' '.join([self.CXX, self.CXXFLAGS, '-I', str(basedir)])
-        return _cplusplus_list_depending_files(path.resolve(), compiler=compiler)
+        joined_CXXFLAGS = ' '.join(map(shlex.quote, [*_get_default_CXXFLAGS(), '-I', str(basedir)]))
+        return _cplusplus_list_depending_files(path.resolve(), CXX=_get_default_CXX(), joined_CXXFLAGS=joined_CXXFLAGS)
 
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bytes:
         bundler = Bundler(iquotes=[basedir])
         bundler.update(path)
         return bundler.get()
+
+    def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[CPlusPlusLanguageEnvironment]:
+        envs = []
+        for env in _list_default_environments():
+            # TODO: 仕様検討 このあたりどうにかする
+            # if 'clang++' in env.CXX.name and 'IGNORE_IF_CLANG' in self.list_attributes(path, basedir=basedir):
+            #     continue
+            # if 'g++' in env.CXX.name and 'IGNORE_IF_GCC' in self.list_attributes(path, basedir=basedir):
+            #     continue
+            if 'clang++' in env.CXX.name and _workaround_ignore_if_clang(path, clang=env.CXX, basedir=basedir):
+                # logger.warning('failed to make the stack size unlimited')
+                # print(f'::warning ::use IGNORE_IF_CLANG')
+                continue
+            envs.append(env)
+        return envs

--- a/onlinejudge_verify/languages/csharpscript.py
+++ b/onlinejudge_verify/languages/csharpscript.py
@@ -8,7 +8,8 @@ import uuid
 from logging import getLogger
 from typing import *
 
-from onlinejudge_verify.languages.base import Language
+from onlinejudge_verify.languages.models import Language, LanguageEnvironment
+from onlinejudge_verify.languages.special_comments import list_special_comments
 
 logger = getLogger(__name__)
 
@@ -90,19 +91,23 @@ def _get_csx_pragmas(path: pathlib.Path) -> Dict[str, str]:
     return res
 
 
-class CSharpScriptLanguage(Language):
+class CSharpScriptLanguageEnvironment(LanguageEnvironment):
     def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
         _publish_csx(path)
-        pass
 
     def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
         return ['dotnet-script', 'exec', str(_publish_csx(path))]
 
+
+class CSharpScriptLanguage(Language):
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
-        return _get_csx_pragmas(path.resolve())
+        return list_special_comments(path.resolve()) or _get_csx_pragmas(path.resolve())
 
     def list_dependencies(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[pathlib.Path]:
         return list(_get_csx_dependencies(path.resolve()))
 
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bytes:
         raise NotImplementedError
+
+    def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Sequence[CSharpScriptLanguageEnvironment]:
+        return [CSharpScriptLanguageEnvironment()]

--- a/onlinejudge_verify/languages/models.py
+++ b/onlinejudge_verify/languages/models.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import *
 
 
-class Language(object):
+class LanguageEnvironment(object):
     @abc.abstractmethod
     def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
         raise NotImplementedError
@@ -13,6 +13,8 @@ class Language(object):
     def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
         raise NotImplementedError
 
+
+class Language(object):
     @abc.abstractmethod
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
         raise NotImplementedError
@@ -27,3 +29,7 @@ class Language(object):
 
     def is_verification_file(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bool:
         return '.test.' in path.name
+
+    @abc.abstractmethod
+    def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Sequence[LanguageEnvironment]:
+        raise NotImplementedError

--- a/onlinejudge_verify/languages/other.py
+++ b/onlinejudge_verify/languages/other.py
@@ -5,12 +5,12 @@ import subprocess
 from logging import getLogger
 from typing import *
 
-from onlinejudge_verify.languages.base import Language
+from onlinejudge_verify.languages.models import Language, LanguageEnvironment
 
 logger = getLogger(__name__)
 
 
-class OtherLanguage(Language):
+class OtherLanguageEnvironment(LanguageEnvironment):
     config: Dict[str, str]
 
     def __init__(self, *, config: Dict[str, str]):
@@ -24,6 +24,13 @@ class OtherLanguage(Language):
     def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
         command = self.config['execute'].format(path=str(path), basedir=str(basedir), tempdir=str(tempdir))
         return shlex.split(command)
+
+
+class OtherLanguage(Language):
+    config: Dict[str, str]
+
+    def __init__(self, *, config: Dict[str, str]):
+        self.config = config
 
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
         command = self.config['list_attributes'].format(path=str(path), basedir=str(basedir))
@@ -52,3 +59,6 @@ class OtherLanguage(Language):
         if suffix is not None:
             return path.name.endswith(suffix)
         return super().is_verification_file(path, basedir=basedir)
+
+    def list_environments(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Sequence[OtherLanguageEnvironment]:
+        return [OtherLanguageEnvironment(config=self.config)]

--- a/onlinejudge_verify/languages/other.py
+++ b/onlinejudge_verify/languages/other.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from typing import *
 
 from onlinejudge_verify.languages.models import Language, LanguageEnvironment
+from onlinejudge_verify.languages.special_comments import list_special_comments
 
 logger = getLogger(__name__)
 
@@ -17,11 +18,13 @@ class OtherLanguageEnvironment(LanguageEnvironment):
         self.config = config
 
     def compile(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> None:
+        assert 'compile' in self.config
         command = self.config['compile'].format(path=str(path), basedir=str(basedir), tempdir=str(tempdir))
         logger.info('$ %s', command)
         subprocess.check_call(shlex.split(command))
 
     def get_execute_command(self, path: pathlib.Path, *, basedir: pathlib.Path, tempdir: pathlib.Path) -> List[str]:
+        assert 'execute' in self.config
         command = self.config['execute'].format(path=str(path), basedir=str(basedir), tempdir=str(tempdir))
         return shlex.split(command)
 
@@ -33,6 +36,9 @@ class OtherLanguage(Language):
         self.config = config
 
     def list_attributes(self, path: pathlib.Path, *, basedir: pathlib.Path) -> Dict[str, str]:
+        if 'list_attributes' not in self.config:
+            return list_special_comments(path)
+
         command = self.config['list_attributes'].format(path=str(path), basedir=str(basedir))
         text = subprocess.check_output(shlex.split(command))
         attributes = {}
@@ -42,6 +48,7 @@ class OtherLanguage(Language):
         return attributes
 
     def list_dependencies(self, path: pathlib.Path, *, basedir: pathlib.Path) -> List[pathlib.Path]:
+        assert 'list_dependencies' in self.config
         command = self.config['list_dependencies'].format(path=str(path), basedir=str(basedir))
         text = subprocess.check_output(shlex.split(command))
         dependencies = [path]
@@ -50,6 +57,7 @@ class OtherLanguage(Language):
         return dependencies
 
     def bundle(self, path: pathlib.Path, *, basedir: pathlib.Path) -> bytes:
+        assert 'bundle' in self.config
         command = self.config['bundle'].format(path=str(path), basedir=str(basedir))
         logger.info('$ %s', command)
         return subprocess.check_output(shlex.split(command))

--- a/onlinejudge_verify/languages/special_comments.py
+++ b/onlinejudge_verify/languages/special_comments.py
@@ -1,0 +1,26 @@
+# Python Version: 3.x
+import functools
+import pathlib
+import re
+from logging import getLogger
+from typing import *
+
+logger = getLogger(__name__)
+
+
+# special comments like Vim and Python: see https://www.python.org/dev/peps/pep-0263/
+@functools.lru_cache(maxsize=None)
+def list_special_comments(path: pathlib.Path) -> Dict[str, str]:
+    pattern = re.compile(r'\bverify-helper:\s*([0-9A-Z_]+)\s*(?:=(.*))?$')
+    failure_pattern = re.compile(r'\bverify-helper:')
+    attributes = {}
+    with open(path) as fh:
+        for line in fh.readlines():
+            matched = pattern.match(line)
+            if matched:
+                key = matched.group(1)
+                value = matched.group(2).strip()
+                attributes[key] = value
+            elif failure_pattern.match(line):
+                logger.warning('broken verify-helper special comment found: %s', line)
+    return attributes


### PR DESCRIPTION
1. fix #173 cc @masutech16: `g++` や `clang++` は存在するものだけ使う (存在しなかったら無視する) ようにします
2. 使うコンパイラやオプションを設定で指定できるようにします (下のコード)
3. 環境変数 `CXX` や `CXXFLAGS` を利用する方式は deprecated とします。警告を出して、しばらく待ってから (半年くらい？) で削除します

``` toml
[[languages.cpp.environments]]
CXX = "g++"

[[languages.cpp.environments]]
CXX = "clang++"

[[languages.cpp.environments]]
CXX = "g++"
CXXFLAGS = ["-std=c++17", "-Wall", "-g", "-fsanitize=undefined", "-D_GLIBCXX_DEBUG"]
```

