### PR TITLE
remove redundant escape

### DIFF
--- a/onlinejudge_verify/marker.py
+++ b/onlinejudge_verify/marker.py
@@ -126,7 +126,7 @@ def _get_last_commit_time_to_verify(path: pathlib.Path) -> datetime.datetime:
     language = onlinejudge_verify.languages.get(path)
     assert language is not None
     depending_files = language.list_dependencies(path, basedir=pathlib.Path.cwd())
-    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + map(str, depending_files)
+    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + list(map(str, depending_files))
     timestamp = subprocess.check_output(code).decode().strip()
     if not timestamp:
         return datetime.datetime.fromtimestamp(0, tz=datetime.timezone(datetime.timedelta()))

--- a/onlinejudge_verify/marker.py
+++ b/onlinejudge_verify/marker.py
@@ -4,7 +4,6 @@ import datetime
 import functools
 import json
 import pathlib
-import shlex
 import subprocess
 from typing import *
 

--- a/onlinejudge_verify/marker.py
+++ b/onlinejudge_verify/marker.py
@@ -126,7 +126,7 @@ def _get_last_commit_time_to_verify(path: pathlib.Path) -> datetime.datetime:
     language = onlinejudge_verify.languages.get(path)
     assert language is not None
     depending_files = language.list_dependencies(path, basedir=pathlib.Path.cwd())
-    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + depending_files
+    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + map(str, depending_files)
     timestamp = subprocess.check_output(code).decode().strip()
     if not timestamp:
         return datetime.datetime.fromtimestamp(0, tz=datetime.timezone(datetime.timedelta()))

--- a/onlinejudge_verify/marker.py
+++ b/onlinejudge_verify/marker.py
@@ -127,7 +127,7 @@ def _get_last_commit_time_to_verify(path: pathlib.Path) -> datetime.datetime:
     language = onlinejudge_verify.languages.get(path)
     assert language is not None
     depending_files = language.list_dependencies(path, basedir=pathlib.Path.cwd())
-    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + list(map(lambda x: shlex.quote(str(x)), depending_files))
+    code = ['git', 'log', '-1', '--date=iso', '--pretty=%ad', '--'] + depending_files
     timestamp = subprocess.check_output(code).decode().strip()
     if not timestamp:
         return datetime.datetime.fromtimestamp(0, tz=datetime.timezone(datetime.timedelta()))


### PR DESCRIPTION
fix #208 

> args はすべての呼び出しに必要で、文字列あるいはプログラム引数のシーケンスでなければなりません。一般に、引数のシーケンスを渡す方が望ましいです。なぜなら、モジュールが必要な引数のエスケープやクオート (例えばファイル名中のスペースを許すこと) の面倒を見ることができるためです。

[subprocess](https://docs.python.org/ja/3/library/subprocess.html)より
