### PR TITLE
v4.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='online-judge-verify-helper',
-    version='4.9.1',
+    version='4.9.2',
     author='Kimiyuki Onaka',
     author_email='kimiyuki95@gmail.com',
     url='https://github.com/kmyk/online-judge-verify-helper',


### PR DESCRIPTION
- fix the behavior when `languages.*.list_attributes` is ommited
- mark `languages.*.list_attributes` in `.verify-helper/config.toml` obsoleted